### PR TITLE
Manual Heading Option

### DIFF
--- a/secretx.dtx
+++ b/secretx.dtx
@@ -293,8 +293,21 @@
 \@ifclassloaded{beamer}{}{%
     \RequirePackage{fancyhdr}%
 }
+\RequirePackage{iftex}
+\RequirePackage{kvoptions}
 \RequirePackage{zref-user}
 \RequirePackage{zref-abspage}
+%    \end{macrocode}
+%
+% \subsection{Manual Heading Override}
+%
+% This optional key-value pair is used to induce a manual override of
+% page-level headings.  All pages will be marked with the indicated
+% heading if this option is specified.
+%
+%    \begin{macrocode}
+\DeclareStringOption{manheading}
+\ProcessKeyvalOptions*
 %    \end{macrocode}
 %
 % \subsection{Package Counters}
@@ -381,17 +394,21 @@
 % \end{macro}
 %
 % \begin{macro}{\getheading}
-% Get the heading on the page.  By default, use the current page level.
+% Get the heading on the page.  By default, use the current page level.  If the \emph{manheading} option is specified, use its value on all pages.
 %    \begin{macrocode}
 \newrobustcmd{\getheading}[1][\thesecretx@pagelevel]{%
-    \ifcsdef{secretx@heading#1}{%
-        \csuse{secretx@heading#1}%
-    }{%
-        \PackageError{secretx}{Undefined heading level}{%
-            Marking #1 level was not previously defined.  Is it a typo
-            or did you simply forget to define it?%
+    \ifx\secretx@manheading\@empty
+        \ifcsdef{secretx@heading#1}{%
+            \csuse{secretx@heading#1}%
+        }{%
+            \PackageError{secretx}{Undefined heading level}{%
+                Marking #1 level was not previously defined.  Is it a typo
+               or did you simply forget to define it?%
+            }
         }
-    }
+    \else
+        \secretx@manheading
+    \fi
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
Added package option for manual heading to be applied to all pages instead of calculated heading.  This allows for document level heading to be used if there are issues with calculating page-level headings (which there currently are).