### PR TITLE
Correct list markings

### DIFF
--- a/secretx.dtx
+++ b/secretx.dtx
@@ -44,7 +44,7 @@
 %</driver>
 % \fi
 %
-% \CheckSum{244}
+% \CheckSum{258}
 %
 % \CharacterTable
 %  {Upper-case \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -738,15 +738,20 @@
 % margin based on the current marking level.
 %    \begin{macrocode}
 \PushPostHook{par}{%
-    \llap{\getmarking{} \kern\parindent}%
+    \llap{\getmarking{} \kern\dimexpr\parindent+\listOffset\relax}%
 }
 %    \end{macrocode}
 %
 % \changes{v0.8.7}{2019/10/17}{Fix the list markings}
 % To deal with the lists, we need to inject the marking before the
 % bullet or enumeration marking.  For this, we use \textsf{enumitem}.
+% List offset tracker is used to keep list markings in margin.
+% Current implementation does not work with description lists.
 %    \begin{macrocode}
 \setlist{listparindent=\parindent}
+\newlength{\listOffset}
+\setlength{\listOffset}{0pt}
+\setlist{before=\addtolength{\listOffset}{\dimexpr\leftmargin-\itemindent\relax}}
 %    \end{macrocode}
 %
 % And now we need to deal with resetting the page levels correctly.


### PR DESCRIPTION
• Moved markings for enumerate and itemize lists to appear in line with paragraph markings instead of on top of bullets
• Marking description lists is more complex and is currently not supported.